### PR TITLE
Extract `styled-components` content

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/styled-components": "^5.0.1",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
-    "@pwa/cli": "latest",
+    "@pwa/cli": "^0.5.2",
     "@pwa/plugin-sw-workbox": "latest",
     "@pwa/plugin-typescript": "latest",
     "@pwa/preset-react": "latest",

--- a/pwa.config.js
+++ b/pwa.config.js
@@ -1,7 +1,6 @@
 exports.babel = function (config) {
 	config.plugins.push(
 		['babel-plugin-styled-components', {
-			transpileTemplateLiterals: true,
 			pure: true,
 		}]
 	);

--- a/pwa.config.js
+++ b/pwa.config.js
@@ -1,6 +1,8 @@
-exports.babel = function(config) {
-	config.plugins.push([
-		'styled-components',
-		{ ssr: true, displayName: true, preprocess: false },
-	]);
-};
+exports.babel = function (config) {
+	config.plugins.push(
+		['babel-plugin-styled-components', {
+			transpileTemplateLiterals: true,
+			pure: true,
+		}]
+	);
+}

--- a/src/components/TheButton.tsx
+++ b/src/components/TheButton.tsx
@@ -26,9 +26,14 @@ const StartButton = styled(Box)`
 	border: 0;
 	border-radius: 50%;
 	color: ${p => p.theme.colors.bg};
+	opacity: 1;
 	will-change: opacity;
 	transition: opacity 0.7s cubic-bezier(0.61, 1, 0.88, 1),
 		background-color 0.2s ease-in-out;
+
+	&[disabled] {
+		opacity: 0;
+	}
 
 	&:hover,
 	&:active {
@@ -47,10 +52,15 @@ const ResetButton = styled(Box)`
 	padding: 0;
 	color: ${p => p.theme.colors.primary};
 	border: 0;
+	opacity: 1;
 	border-radius: 50%;
 	will-change: opacity;
 	transition: opacity 0.7s cubic-bezier(0.61, 1, 0.88, 1),
 		background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+
+	&[disabled] {
+		opacity: 0;
+	}
 
 	&:hover,
 	&:active {
@@ -97,7 +107,6 @@ export const TheButton = ({
 			onClick={onStart}
 			aria-label="Start timer"
 			disabled={status === 'running'}
-			opacity={status === 'running' ? 0 : 1}
 		>
 			<Box position="relative" left="0.2rem">
 				<Icon icon="play" size={64} />
@@ -116,7 +125,6 @@ export const TheButton = ({
 				onClick={onReset}
 				aria-label="Rest timer"
 				disabled={status !== 'running'}
-				opacity={status === 'running' ? 1 : 0}
 			>
 				<Icon icon="reset" size={28} />
 			</ResetButton>

--- a/src/components/TheButton.tsx
+++ b/src/components/TheButton.tsx
@@ -26,14 +26,9 @@ const StartButton = styled(Box)`
 	border: 0;
 	border-radius: 50%;
 	color: ${p => p.theme.colors.bg};
-	opacity: 1;
 	will-change: opacity;
 	transition: opacity 0.7s cubic-bezier(0.61, 1, 0.88, 1),
 		background-color 0.2s ease-in-out;
-
-	&[disabled] {
-		opacity: 0;
-	}
 
 	&:hover,
 	&:active {
@@ -52,15 +47,10 @@ const ResetButton = styled(Box)`
 	padding: 0;
 	color: ${p => p.theme.colors.primary};
 	border: 0;
-	opacity: 1;
 	border-radius: 50%;
 	will-change: opacity;
 	transition: opacity 0.7s cubic-bezier(0.61, 1, 0.88, 1),
 		background-color 0.2s ease-in-out, color 0.2s ease-in-out;
-
-	&[disabled] {
-		opacity: 0;
-	}
 
 	&:hover,
 	&:active {
@@ -107,6 +97,7 @@ export const TheButton = ({
 			onClick={onStart}
 			aria-label="Start timer"
 			disabled={status === 'running'}
+			opacity={status === 'running' ? 0 : 1}
 		>
 			<Box position="relative" left="0.2rem">
 				<Icon icon="play" size={64} />
@@ -125,6 +116,7 @@ export const TheButton = ({
 				onClick={onReset}
 				aria-label="Rest timer"
 				disabled={status !== 'running'}
+				opacity={status === 'running' ? 1 : 0}
 			>
 				<Icon icon="reset" size={28} />
 			</ResetButton>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 import { IndexPage } from './pages/index';
 
-if (process.env.NODE_ENV === 'production') {
+if (window.PWA_EXPORT) {
 	const sheet = new ServerStyleSheet();
 
 	ReactDOM.hydrate(
@@ -16,11 +16,13 @@ if (process.env.NODE_ENV === 'production') {
 			sheet.seal();
 		}
 	);
-
-	// Service Worker registration
-	// if ('serviceWorker' in navigator) {
-	// 	navigator.serviceWorker.register('/sw.js');
-	// }
 } else {
-	ReactDOM.render(<IndexPage />, document.getElementById('app'));
+	// if (process.env.NODE_ENV === 'production') {
+	// 	// Service Worker registration
+	// 	if ('serviceWorker' in navigator) {
+	// 		navigator.serviceWorker.register('/sw.js');
+	// 	}
+	// }
+
+	ReactDOM.hydrate(<IndexPage />, document.getElementById('app'));
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 import { IndexPage } from './pages/index';
 
-ReactDOM.render(<IndexPage />, document.getElementById('app'));
+if (process.env.NODE_ENV === 'production') {
+	const sheet = new ServerStyleSheet();
 
-// if (process.env.NODE_ENV === 'production') {
-// 	// Service Worker registration
-// 	if ('serviceWorker' in navigator) {
-// 		navigator.serviceWorker.register('/sw.js');
-// 	}
-// }
+	ReactDOM.hydrate(
+		[
+			<StyleSheetManager sheet={ sheet.instance }>
+				<IndexPage/>
+			</StyleSheetManager>,
+			React.createElement(() => sheet.getStyleElement())
+		],
+		document.getElementById('app'),
+	);
+
+	// Service Worker registration
+	// if ('serviceWorker' in navigator) {
+	// 	navigator.serviceWorker.register('/sw.js');
+	// }
+} else {
+	ReactDOM.render(<IndexPage />, document.getElementById('app'));
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,13 +7,14 @@ if (process.env.NODE_ENV === 'production') {
 	const sheet = new ServerStyleSheet();
 
 	ReactDOM.hydrate(
-		[
-			<StyleSheetManager sheet={ sheet.instance }>
-				<IndexPage/>
-			</StyleSheetManager>,
-			React.createElement(() => sheet.getStyleElement())
-		],
+		<StyleSheetManager sheet={ sheet.instance }>
+			<IndexPage/>
+		</StyleSheetManager>,
 		document.getElementById('app'),
+		() => {
+			document.head.innerHTML += sheet.getStyleTags();
+			sheet.seal();
+		}
 	);
 
 	// Service Worker registration


### PR DESCRIPTION
* extracts inline `<style>` rules to `document.head` 😉 
* fixes `TheButton` members in accordance to SC classname generation

The original gist/suggestions worked correctly. This PR enhances it to move those rules to the head, as per your request.

This PR also fixes/works around something that is purely `styled-components`' doing. I don't think it's even necessarily a bug – they just generate a new classname per property modifier (eg, your `[disabled]` _and_ `[opacity]` attributes) and then expect their users to redefine (or use `styled-theme` ... or manually extend) all styles for all variants. 😬 

So, the dynamic portions were always working. The problem was that your base-class identifiers were replaced with empty rules.

---

PS: I skipped precommit hooks because they didn't work on my machine. It was missing `prettier` which I assume you have installed globally